### PR TITLE
Rework memory copy for cases where pitch > data

### DIFF
--- a/outputduplication/output_duplication.go
+++ b/outputduplication/output_duplication.go
@@ -266,16 +266,6 @@ func (dup *OutputDuplicator) GetImage(img *image.RGBA, timeoutMs uint) error {
 		swizzle.BGRA(img.Pix)
 	}
 
-	// manual swizzle B <-> R
-
-	// for i := int32(0); i < bitmapDataSize; i += 4 {
-	// 	v0 := *(*uint8)(unsafe.Pointer(hMem + uintptr(i)))
-	// 	v1 := *(*uint8)(unsafe.Pointer(hMem + uintptr(i) + 1))
-	// 	v2 := *(*uint8)(unsafe.Pointer(hMem + uintptr(i) + 2))
-
-	// 	// BGRA => RGBA, no need to read alpha, always 255.
-	// 	img.Pix[i], img.Pix[i+1], img.Pix[i+2], img.Pix[i+3] = v2, v1, v0, 255
-	// }
 	return nil
 }
 

--- a/outputduplication/output_duplication.go
+++ b/outputduplication/output_duplication.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"image"
 
-	"reflect"
 	"unsafe"
 
 	"github.com/kirides/go-d3d"
@@ -242,16 +241,11 @@ func (dup *OutputDuplicator) GetImage(img *image.RGBA, timeoutMs uint) error {
 
 	// docs are unclear, but pitch is the total width of each row
 	dataSize := int(mappedRect.Pitch) * int(size.Y)
-
-	var data []byte
-	sh := (*reflect.SliceHeader)(unsafe.Pointer(&data))
-	sh.Data = mappedRect.PBits
-	sh.Len = dataSize
-	sh.Cap = dataSize
+	data := unsafe.Slice((*byte)(unsafe.Pointer(mappedRect.PBits)), dataSize)
 
 	contentWidth := int(size.X) * 4
 	dataWidth := int(mappedRect.Pitch)
-	
+
 	var imgStart, dataStart, dataEnd int
 	// copy source bytes into image.RGBA.Pix, skipping padding
 	for i := 0; i < int(size.Y); i++ {

--- a/outputduplication/output_duplication.go
+++ b/outputduplication/output_duplication.go
@@ -255,10 +255,10 @@ func (dup *OutputDuplicator) GetImage(img *image.RGBA, timeoutMs uint) error {
 	var imgStart, dataStart, dataEnd int
 	// copy source bytes into image.RGBA.Pix, skipping padding
 	for i := 0; i < int(size.Y); i++ {
-		imgStart = i * contentWidth
-		dataStart = i * dataWidth
 		dataEnd = dataStart + contentWidth
 		copy(img.Pix[imgStart:], data[dataStart:dataEnd])
+		imgStart += contentWidth
+		dataStart += dataWidth
 	}
 
 	dup.drawPointer(img)


### PR DESCRIPTION
During tests, I could not get the examples to work for Windows 11 21H2 (OS Ver 10.0.22000.2057), specifically when testing over RDP. The device in this case is Microsoft Remote Display Adapter, supporting DirectX 12.

All tests resulted in garbled output like this:
![test](https://github.com/kirides/go-d3d/assets/6495713/bef38f1e-28f7-4a70-85e7-cc0d91695dd9)

While debugging the issue I noticed the straight-forward memory copy, which ignores the pitch. Fixing the copy also removes my error. Relevant documentation regarding correctness of this change:

https://learn.microsoft.com/en-us/windows/win32/api/dxgi/ns-dxgi-dxgi_mapped_rect
https://learn.microsoft.com/en-us/windows/win32/api/d3d11/ns-d3d11-d3d11_mapped_subresource

```
RowPitch
Type: [UINT](https://learn.microsoft.com/en-us/windows/desktop/WinProg/windows-data-types)
The row pitch, or width, or physical size (in bytes) of the data.
[...]
RowPitch contains the value that the runtime adds to pData to move from row to row, where each row contains multiple pixels.
[...]
Note: The runtime might assign values to RowPitch and DepthPitch that are larger than anticipated because there might be padding between rows and depth.
```

Looking forward to your feedback :)