### PR TITLE
Go 1.24, Monochrome cursor, updated mjpeg example

### DIFF
--- a/com/iunknown_vtbl.go
+++ b/com/iunknown_vtbl.go
@@ -1,6 +1,9 @@
 package com
 
+import "structs"
+
 type IUnknownVtbl struct {
+	_ structs.HostLayout
 	// every COM object starts with these three
 	QueryInterface uintptr
 	AddRef         uintptr

--- a/d3d11/d3d11.go
+++ b/d3d11/d3d11.go
@@ -2,6 +2,7 @@ package d3d11
 
 import (
 	"fmt"
+	"structs"
 	"syscall"
 	"unsafe"
 
@@ -102,6 +103,7 @@ func NewD3D11Device() (*ID3D11Device, *ID3D11DeviceContext, error) {
 }
 
 type ID3D11Texture2D struct {
+	_    structs.HostLayout
 	vtbl *ID3D11Texture2DVtbl
 }
 
@@ -125,6 +127,7 @@ func (obj *ID3D11Texture2D) QueryInterface(iid windows.GUID, pp interface{}) int
 }
 
 type ID3D11Device struct {
+	_    structs.HostLayout
 	vtbl *ID3D11DeviceVtbl
 }
 
@@ -152,6 +155,7 @@ func (obj *ID3D11Device) Release() int32 {
 }
 
 type ID3D11Device1 struct {
+	_    structs.HostLayout
 	vtbl *ID3D11DeviceVtbl
 }
 
@@ -175,6 +179,7 @@ func (obj *ID3D11Device1) CreateTexture2D(desc *D3D11_TEXTURE2D_DESC, ppTexture2
 }
 
 type ID3D11DeviceContext struct {
+	_    structs.HostLayout
 	vtbl *ID3D11DeviceContextVtbl
 }
 
@@ -236,6 +241,7 @@ func (obj *ID3D11DeviceContext) Release() int32 {
 }
 
 type ID3D11Resource struct {
+	_    structs.HostLayout
 	vtbl *ID3D11ResourceVtbl
 }
 

--- a/d3d11/d3d11_types.go
+++ b/d3d11/d3d11_types.go
@@ -1,12 +1,20 @@
 package d3d11
 
-import "github.com/kirides/go-d3d/dxgi"
+import (
+	"structs"
+
+	"github.com/kirides/go-d3d/dxgi"
+)
 
 type D3D11_BOX struct {
+	_ structs.HostLayout
+
 	Left, Top, Front, Right, Bottom, Back uint32
 }
 
 type D3D11_TEXTURE2D_DESC struct {
+	_ structs.HostLayout
+
 	Width          uint32
 	Height         uint32
 	MipLevels      uint32

--- a/d3d11/d3d11_vtbl.go
+++ b/d3d11/d3d11_vtbl.go
@@ -1,10 +1,14 @@
 package d3d11
 
 import (
+	"structs"
+
 	"github.com/kirides/go-d3d/com"
 )
 
 type ID3D11DeviceChildVtbl struct {
+	_ structs.HostLayout
+
 	com.IUnknownVtbl
 
 	GetDevice               uintptr
@@ -14,6 +18,7 @@ type ID3D11DeviceChildVtbl struct {
 }
 
 type ID3D11DeviceContextVtbl struct {
+	_ structs.HostLayout
 	ID3D11DeviceChildVtbl
 
 	VSSetConstantBuffers                      uintptr
@@ -62,6 +67,7 @@ type ID3D11DeviceContextVtbl struct {
 }
 
 type ID3D11DeviceVtbl struct {
+	_ structs.HostLayout
 	com.IUnknownVtbl
 
 	CreateBuffer                         uintptr
@@ -107,6 +113,7 @@ type ID3D11DeviceVtbl struct {
 }
 
 type ID3D11DebugVtbl struct {
+	_ structs.HostLayout
 	com.IUnknownVtbl
 
 	SetFeatureMask             uintptr
@@ -121,6 +128,7 @@ type ID3D11DebugVtbl struct {
 }
 
 type ID3D11InfoQueueVtbl struct {
+	_ structs.HostLayout
 	com.IUnknownVtbl
 
 	AddApplicationMessage                        uintptr
@@ -160,6 +168,7 @@ type ID3D11InfoQueueVtbl struct {
 	SetMuteDebugOutput                           uintptr
 }
 type ID3D11ResourceVtbl struct {
+	_ structs.HostLayout
 	ID3D11DeviceChildVtbl
 
 	GetType             uintptr
@@ -168,6 +177,7 @@ type ID3D11ResourceVtbl struct {
 }
 
 type ID3D11Texture2DVtbl struct {
+	_ structs.HostLayout
 	ID3D11ResourceVtbl
 
 	GetDesc uintptr

--- a/d3d11/d3d11debug.go
+++ b/d3d11/d3d11debug.go
@@ -1,6 +1,7 @@
 package d3d11
 
 import (
+	"structs"
 	"syscall"
 	"unsafe"
 
@@ -9,6 +10,7 @@ import (
 )
 
 type ID3D11Debug struct {
+	_    structs.HostLayout
 	vtbl *ID3D11DebugVtbl
 }
 
@@ -37,6 +39,7 @@ func (obj *ID3D11Debug) Release() int32 {
 }
 
 type ID3D11InfoQueue struct {
+	_    structs.HostLayout
 	vtbl *ID3D11InfoQueueVtbl
 }
 

--- a/dxgi/dxgi.go
+++ b/dxgi/dxgi.go
@@ -1,6 +1,7 @@
 package dxgi
 
 import (
+	"structs"
 	"syscall"
 	"unsafe"
 
@@ -32,6 +33,7 @@ const (
 )
 
 type IDXGIFactory1 struct {
+	_    structs.HostLayout
 	vtbl *IDXGIFactory1Vtbl
 }
 
@@ -67,6 +69,7 @@ func CreateDXGIFactory1(ppFactory **IDXGIFactory1) error {
 }
 
 type IDXGIAdapter1 struct {
+	_    structs.HostLayout
 	vtbl *IDXGIAdapter1Vtbl
 }
 
@@ -89,6 +92,7 @@ func (obj *IDXGIAdapter1) EnumOutputs(output uint32, pp **IDXGIOutput) uint32 {
 }
 
 type IDXGIAdapter struct {
+	_    structs.HostLayout
 	vtbl *IDXGIAdapterVtbl
 }
 
@@ -111,6 +115,7 @@ func (obj *IDXGIAdapter) Release() int32 {
 }
 
 type IDXGIDevice struct {
+	_    structs.HostLayout
 	vtbl *IDXGIDeviceVtbl
 }
 
@@ -151,6 +156,7 @@ func (obj *IDXGIDevice) Release() int32 {
 }
 
 type IDXGIDevice1 struct {
+	_    structs.HostLayout
 	vtbl *IDXGIDevice1Vtbl
 }
 
@@ -186,6 +192,7 @@ func (obj *IDXGIDevice1) Release() int32 {
 }
 
 type IDXGIOutput struct {
+	_    structs.HostLayout
 	vtbl *IDXGIOutputVtbl
 }
 
@@ -212,6 +219,7 @@ func (obj *IDXGIOutput) Release() int32 {
 }
 
 type IDXGIOutput1 struct {
+	_    structs.HostLayout
 	vtbl *IDXGIOutput1Vtbl
 }
 
@@ -244,6 +252,7 @@ func (obj *IDXGIOutput1) Release() int32 {
 }
 
 type IDXGIOutput5 struct {
+	_    structs.HostLayout
 	vtbl *IDXGIOutput5Vtbl
 }
 
@@ -291,6 +300,7 @@ func (obj *IDXGIOutput5) Release() int32 {
 }
 
 type IDXGIResource struct {
+	_    structs.HostLayout
 	vtbl *IDXGIResourceVtbl
 }
 
@@ -306,6 +316,7 @@ func (obj *IDXGIResource) Release() int32 {
 }
 
 type IDXGISurface struct {
+	_    structs.HostLayout
 	vtbl *IDXGISurfaceVtbl
 }
 
@@ -337,6 +348,7 @@ func (obj *IDXGISurface) Release() int32 {
 }
 
 type IDXGIOutputDuplication struct {
+	_    structs.HostLayout
 	vtbl *IDXGIOutputDuplicationVtbl
 }
 

--- a/dxgi/dxgi_types.go
+++ b/dxgi/dxgi_types.go
@@ -1,8 +1,12 @@
 package dxgi
 
+import "structs"
+
 //go:generate stringer -type=_DXGI_OUTDUPL_POINTER_SHAPE_TYPE -output=dxgi_types_string.go
 
 type DXGI_RATIONAL struct {
+	_ structs.HostLayout
+
 	Numerator   uint32
 	Denominator uint32
 }
@@ -10,6 +14,8 @@ type DXGI_RATIONAL struct {
 type DXGI_MODE_ROTATION uint32
 
 type DXGI_OUTPUT_DESC struct {
+	_ structs.HostLayout
+
 	DeviceName         [32]uint16
 	DesktopCoordinates RECT
 	AttachedToDesktop  uint32 // BOOL
@@ -18,6 +24,8 @@ type DXGI_OUTPUT_DESC struct {
 }
 
 type DXGI_MODE_DESC struct {
+	_ structs.HostLayout
+
 	Width            uint32
 	Height           uint32
 	Rational         DXGI_RATIONAL
@@ -27,33 +35,47 @@ type DXGI_MODE_DESC struct {
 }
 
 type DXGI_OUTDUPL_DESC struct {
+	_ structs.HostLayout
+
 	ModeDesc                   DXGI_MODE_DESC
 	Rotation                   uint32 // DXGI_MODE_ROTATION
 	DesktopImageInSystemMemory uint32 // BOOL
 }
 
 type DXGI_SAMPLE_DESC struct {
+	_ structs.HostLayout
+
 	Count   uint32
 	Quality uint32
 }
 
 type POINT struct {
+	_ structs.HostLayout
+
 	X int32
 	Y int32
 }
 type RECT struct {
+	_ structs.HostLayout
+
 	Left, Top, Right, Bottom int32
 }
 
 type DXGI_OUTDUPL_MOVE_RECT struct {
+	_ structs.HostLayout
+
 	Src  POINT
 	Dest RECT
 }
 type DXGI_OUTDUPL_POINTER_POSITION struct {
+	_ structs.HostLayout
+
 	Position POINT
 	Visible  uint32
 }
 type DXGI_OUTDUPL_FRAME_INFO struct {
+	_ structs.HostLayout
+
 	LastPresentTime           int64
 	LastMouseUpdateTime       int64
 	AccumulatedFrames         uint32
@@ -64,6 +86,8 @@ type DXGI_OUTDUPL_FRAME_INFO struct {
 	PointerShapeBufferSize    uint32
 }
 type DXGI_MAPPED_RECT struct {
+	_ structs.HostLayout
+
 	Pitch int32
 	PBits uintptr
 }
@@ -82,6 +106,8 @@ const (
 )
 
 type DXGI_OUTDUPL_POINTER_SHAPE_INFO struct {
+	_ structs.HostLayout
+
 	Type    DXGI_OUTDUPL_POINTER_SHAPE_TYPE
 	Width   uint32
 	Height  uint32

--- a/dxgi/dxgi_vtbl.go
+++ b/dxgi/dxgi_vtbl.go
@@ -1,10 +1,13 @@
 package dxgi
 
 import (
+	"structs"
+
 	"github.com/kirides/go-d3d/com"
 )
 
 type IDXGIObjectVtbl struct {
+	_ structs.HostLayout
 	com.IUnknownVtbl
 
 	SetPrivateData          uintptr
@@ -14,6 +17,7 @@ type IDXGIObjectVtbl struct {
 }
 
 type IDXGIAdapterVtbl struct {
+	_ structs.HostLayout
 	IDXGIObjectVtbl
 
 	EnumOutputs           uintptr
@@ -21,12 +25,14 @@ type IDXGIAdapterVtbl struct {
 	CheckInterfaceSupport uintptr
 }
 type IDXGIAdapter1Vtbl struct {
+	_ structs.HostLayout
 	IDXGIAdapterVtbl
 
 	GetDesc1 uintptr
 }
 
 type IDXGIDeviceVtbl struct {
+	_ structs.HostLayout
 	IDXGIObjectVtbl
 
 	CreateSurface          uintptr
@@ -37,6 +43,7 @@ type IDXGIDeviceVtbl struct {
 }
 
 type IDXGIDevice1Vtbl struct {
+	_ structs.HostLayout
 	IDXGIDeviceVtbl
 
 	GetMaximumFrameLatency uintptr
@@ -44,12 +51,14 @@ type IDXGIDevice1Vtbl struct {
 }
 
 type IDXGIDeviceSubObjectVtbl struct {
+	_ structs.HostLayout
 	IDXGIObjectVtbl
 
 	GetDevice uintptr
 }
 
 type IDXGISurfaceVtbl struct {
+	_ structs.HostLayout
 	IDXGIDeviceSubObjectVtbl
 
 	GetDesc uintptr
@@ -58,6 +67,7 @@ type IDXGISurfaceVtbl struct {
 }
 
 type IDXGIResourceVtbl struct {
+	_ structs.HostLayout
 	IDXGIDeviceSubObjectVtbl
 
 	GetSharedHandle     uintptr
@@ -67,6 +77,7 @@ type IDXGIResourceVtbl struct {
 }
 
 type IDXGIOutputVtbl struct {
+	_ structs.HostLayout
 	IDXGIObjectVtbl
 
 	GetDesc                     uintptr
@@ -84,6 +95,7 @@ type IDXGIOutputVtbl struct {
 }
 
 type IDXGIOutput1Vtbl struct {
+	_ structs.HostLayout
 	IDXGIOutputVtbl
 
 	GetDisplayModeList1      uintptr
@@ -93,29 +105,34 @@ type IDXGIOutput1Vtbl struct {
 }
 
 type IDXGIOutput2Vtbl struct {
+	_ structs.HostLayout
 	IDXGIOutput1Vtbl
 
 	SupportsOverlays uintptr
 }
 
 type IDXGIOutput3Vtbl struct {
+	_ structs.HostLayout
 	IDXGIOutput2Vtbl
 
 	CheckOverlaySupport uintptr
 }
 
 type IDXGIOutput4Vtbl struct {
+	_ structs.HostLayout
 	IDXGIOutput3Vtbl
 
 	CheckOverlayColorSpaceSupport uintptr
 }
 type IDXGIOutput5Vtbl struct {
+	_ structs.HostLayout
 	IDXGIOutput4Vtbl
 
 	DuplicateOutput1 uintptr
 }
 
 type IDXGIOutputDuplicationVtbl struct {
+	_ structs.HostLayout
 	IDXGIObjectVtbl
 
 	GetDesc              uintptr
@@ -128,6 +145,7 @@ type IDXGIOutputDuplicationVtbl struct {
 	ReleaseFrame         uintptr
 }
 type IDXGIFactoryVtbl struct {
+	_ structs.HostLayout
 	IDXGIObjectVtbl
 
 	EnumAdapters          uintptr
@@ -137,6 +155,7 @@ type IDXGIFactoryVtbl struct {
 	CreateSoftwareAdapter uintptr
 }
 type IDXGIFactory1Vtbl struct {
+	_ structs.HostLayout
 	IDXGIFactoryVtbl
 
 	EnumAdapters1 uintptr

--- a/go.mod
+++ b/go.mod
@@ -1,18 +1,17 @@
 module github.com/kirides/go-d3d
 
-go 1.21
-
-toolchain go1.22.2
+go 1.24
 
 require (
-	github.com/kbinani/screenshot v0.0.0-20230812210009-b87d31814237
+	github.com/kbinani/screenshot v0.0.0-20250118074034-a3924b7bbc8c
 	github.com/mattn/go-mjpeg v0.0.3
 	github.com/viam-labs/go-libjpeg v0.3.1
-	golang.org/x/sys v0.20.0
+	golang.org/x/sys v0.33.0
 )
 
 require (
-	github.com/gen2brain/shm v0.1.0 // indirect
+	github.com/gen2brain/shm v0.1.1 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect
 	github.com/lxn/win v0.0.0-20210218163916-a377121e959e // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,11 @@
-github.com/gen2brain/shm v0.1.0 h1:MwPeg+zJQXN0RM9o+HqaSFypNoNEcNpeoGp0BTSx2YY=
-github.com/gen2brain/shm v0.1.0/go.mod h1:UgIcVtvmOu+aCJpqJX7GOtiN7X2ct+TKLg4RTxwPIUA=
+github.com/gen2brain/shm v0.1.1 h1:1cTVA5qcsUFixnDHl14TmRoxgfWEEZlTezpUj1vm5uQ=
+github.com/gen2brain/shm v0.1.1/go.mod h1:UgIcVtvmOu+aCJpqJX7GOtiN7X2ct+TKLg4RTxwPIUA=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/jezek/xgb v1.1.1 h1:bE/r8ZZtSv7l9gk6nU0mYx51aXrvnyb44892TwSaqS4=
 github.com/jezek/xgb v1.1.1/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=
-github.com/kbinani/screenshot v0.0.0-20230812210009-b87d31814237 h1:YOp8St+CM/AQ9Vp4XYm4272E77MptJDHkwypQHIRl9Q=
-github.com/kbinani/screenshot v0.0.0-20230812210009-b87d31814237/go.mod h1:e7qQlOY68wOz4b82D7n+DdaptZAi+SHW0+yKiWZzEYE=
+github.com/kbinani/screenshot v0.0.0-20250118074034-a3924b7bbc8c h1:1IlzDla/ZATV/FsRn1ETf7ir91PHS2mrd4VMunEtd9k=
+github.com/kbinani/screenshot v0.0.0-20250118074034-a3924b7bbc8c/go.mod h1:Pmpz2BLf55auQZ67u3rvyI2vAQvNetkK/4zYUmpauZQ=
 github.com/lxn/win v0.0.0-20210218163916-a377121e959e h1:H+t6A/QJMbhCSEH5rAuRxh+CtW96g0Or0Fxa9IKr4uc=
 github.com/lxn/win v0.0.0-20210218163916-a377121e959e/go.mod h1:KxxjdtRkfNoYDCUP5ryK7XJJNTnpC8atvtmTheChOtk=
 github.com/mattn/go-mjpeg v0.0.3 h1:0G/+KddrbI5Hnq83B11O1O4vP7Q6L9MsBu6aW71jhUM=
@@ -11,5 +13,5 @@ github.com/mattn/go-mjpeg v0.0.3/go.mod h1:65z7Cj+u5y5K3B8Sy5NtrJFTWAhguGHs9FEkA
 github.com/viam-labs/go-libjpeg v0.3.1 h1:J/byavXHFqRI1PFPrnPbP+wFCr1y+Cn1CwKXrORCPD0=
 github.com/viam-labs/go-libjpeg v0.3.1/go.mod h1:b0ISpf9lJv9MO1h1gXAmSA/osG19cKGYjfYc6aeEjqs=
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
-golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=


### PR DESCRIPTION
- Update to Go 1.24
  - mark structs for windows interop explicitly with structs.HostLayout
- fix drawing monochrome cursor (i.e. cursor on top of VS Code)
- runtime.UnlockOSThread() in mjpeg example
- mjpeg example updated to always output last window but with updated mouse pointer